### PR TITLE
Network.parse_vertices():  Do not assume entire .INP file to be in UTF-8.

### DIFF
--- a/epynet/network.py
+++ b/epynet/network.py
@@ -370,19 +370,19 @@ class Network(object):
         if not self.inputfile or len(self.vertices) > 0:
             return
 
-        with open(self.inputfile, 'r') as handle:
+        with open(self.inputfile, 'rb') as handle:
             for line in handle.readlines():
-                if '[VERTICES]' in line:
+                if b'[VERTICES]' in line:
                     vertices = True
                     continue
-                elif '[' in line:
+                elif b'[' in line:
                     vertices = False
 
-                if "\t" not in line or ";" in line:
+                if b"\t" not in line or b";" in line:
                     continue
 
                 if vertices:
-                    components = [c.strip() for c in line.split("\t")]
+                    components = [c.strip() for c in line.decode('utf-8').split("\t")]
                     if components[0] not in self.vertices:
                         self.vertices[components[0]] = []
                     self.vertices[components[0]].append((float(components[1]), float(components[2])))


### PR DESCRIPTION
With these changes, vertices are imported even if the file contains invalid UTF-8 characters. This can happen if the file contains element names in nonstandard character sets.